### PR TITLE
whitenoise

### DIFF
--- a/dbbackend/settings.py
+++ b/dbbackend/settings.py
@@ -45,6 +45,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ psycopg2-binary
 enum34
 gunicorn
 dj-database-url
+whitenoise
 django-colorful
 pillow
 boto3


### PR DESCRIPTION
This is needed for serving static files eg css files for djangos personal use.