### PR TITLE
Nav context fix+text

### DIFF
--- a/confabulation/tests/test_site_contexts.py
+++ b/confabulation/tests/test_site_contexts.py
@@ -1,0 +1,59 @@
+from django.test import TestCase
+from ..models import ParticipantTypes, Participant, AnalysisType, AnalysisPoint
+import mock
+from .db_data import populate_db
+from ..views.navbar import navigation_context
+
+class NavigationContext(TestCase):
+
+    def setUp(self):
+        populate_db()
+
+    def empty_query_set(name="", participation_group="", analysis_type_id=""):
+        return Participant.objects.none()
+
+    def test_nav_context_initialized(self):
+        context=navigation_context()
+        for item in ['participants', 'taxonomy', 'confabulation']:
+            self.assertTrue(item in context)
+
+    def test_nav_context_full_db(self):
+        context=navigation_context()
+        self.assertTrue(len(context['participants']) > 0)
+        for p in context['participants']:
+            self.assertTrue(len(p) > 0)
+
+        self.assertTrue(len(context['taxonomy']) > 0)
+        for t in context['taxonomy']:
+            self.assertTrue(len(t) > 0)
+
+        self.assertTrue(len(context['confabulation']) > 0)
+        for c in context['confabulation']:
+            self.assertTrue(len(c) > 0)
+
+    @mock.patch('confabulation.views.navbar.Participant.objects.filter', empty_query_set)
+    def test_nav_context_no_participants(self):
+        context=navigation_context()
+        self.assertTrue('participants' in context)
+        for p in context['participants']:
+            self.assertEqual(context['participants'][p], [])
+
+    @mock.patch('confabulation.views.navbar.AnalysisType.objects.all', empty_query_set)
+    def test_nav_context_no_analysys_types(self):
+        context=navigation_context()
+        self.assertTrue('taxonomy' in context)
+        self.assertEqual(len(context['taxonomy']), 0)
+
+    @mock.patch('confabulation.views.navbar.AnalysisPoint.objects.filter', empty_query_set)
+    def test_nav_context_no_analysis_points(self):
+        context=navigation_context()
+        self.assertTrue('taxonomy' in context)
+        self.assertTrue(len(context['taxonomy'])>0)
+        for t in context['taxonomy']:
+            self.assertEqual(len(context['taxonomy'][t]), 0)
+
+    @mock.patch('confabulation.views.navbar.AnalysisType.objects.filter', empty_query_set)
+    def test_nav_context_no_Confabulation_type(self):
+        context=navigation_context()
+        self.assertTrue('confabulation' in context)
+        self.assertEqual(len(context['confabulation']), 0)

--- a/confabulation/views/navbar.py
+++ b/confabulation/views/navbar.py
@@ -3,7 +3,9 @@ from ..models import ParticipantTypes, Participant, AnalysisType, AnalysisPoint
 def navigation_context():
     context = {'participants':{},
                'taxonomy':{},
-               'confabulation':{}}
+               'confabulation':[]
+              }
+
     participant_types = ParticipantTypes.choices()
     for pt in participant_types:
         pt_name = pt[0]
@@ -13,16 +15,18 @@ def navigation_context():
 
     taxonomy_types = AnalysisType.objects.all()
     for t in taxonomy_types:
+        context['taxonomy'][t.name] = []
         ap_list = AnalysisPoint.objects.filter(analysis_type_id=t.id)
 
         ap_list_by_type = [{"name": ap.name,
                            "link": ap.get_absolute_url()} for ap in ap_list]
         context['taxonomy'][t.name] = ap_list_by_type
 
-    confab_type = AnalysisType.objects.get(name='Confabulation')
-    confab_points = AnalysisPoint.objects.filter(analysis_type_id=confab_type.id)
-    confabulation_points = [{"name": ap.name, 'link': ap.get_absolute_url()} for ap in confab_points]
-    context['confabulation'] = confabulation_points
+    confab_types = AnalysisType.objects.filter(name='Confabulation')
+    if confab_types.count()>0:
+        confab_points = AnalysisPoint.objects.filter(analysis_type_id=confab_types[0].id)
+        confabulation_points = [{"name": ap.name, 'link': ap.get_absolute_url()} for ap in confab_points]
+        context['confabulation'] = confabulation_points
 
     return context
 


### PR DESCRIPTION
Previously the nav context creation only worked if the db was populated with right data. 
This prevents the site from working on an unpopulated DB, which is the case for tests, and manual trying of the system. basically I want to be able to start the site without having to fill it with data. 

plus tests. 