### PR TITLE
fix story page ordering

### DIFF
--- a/confabulation/utils/story_sorter.py
+++ b/confabulation/utils/story_sorter.py
@@ -6,7 +6,7 @@ def get_sortable_number(story):
     if m:
         match = m.group()
         return int(match)
-    return name
+    return 0
 
 def sort_story_list(story_list):
     story_list.sort(key=get_sortable_number)


### PR DESCRIPTION
the story sorter presumes that all stories have numbers in their names. They don't. Change behavior to always have use 0 for ordering stories with no numbers. 